### PR TITLE
Show correct glass hitbox for 1.13 clients on or below 1.8 servers

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/blockconnections/GlassConnectionHandler.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/blockconnections/GlassConnectionHandler.java
@@ -34,6 +34,6 @@ public class GlassConnectionHandler extends AbstractFenceConnectionHandler {
     @Override
     protected Byte getStates(UserConnection user, Position position, int blockState) {
         final Byte states = super.getStates(user, position, blockState);
-        return states == 0 && (ProtocolRegistry.SERVER_PROTOCOL <= 47 && ProtocolRegistry.SERVER_PROTOCOL != -1) ? 15 : states;
+        return states == 0 && (ProtocolRegistry.SERVER_PROTOCOL <= 47 && ProtocolRegistry.SERVER_PROTOCOL != -1) ? 0xF : states;
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/blockconnections/GlassConnectionHandler.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/blockconnections/GlassConnectionHandler.java
@@ -1,11 +1,10 @@
 package us.myles.ViaVersion.protocols.protocol1_13to1_12_2.blockconnections;
 
 import us.myles.ViaVersion.api.data.UserConnection;
-import us.myles.ViaVersion.api.minecraft.BlockFace;
 import us.myles.ViaVersion.api.minecraft.Position;
 import us.myles.ViaVersion.api.protocol.ProtocolRegistry;
 
-public class GlassConnectionHandler extends AbstractFenceConnectionHandler{
+public class GlassConnectionHandler extends AbstractFenceConnectionHandler {
 
     static void init() {
         new GlassConnectionHandler("paneConnections", "minecraft:white_stained_glass_pane");
@@ -32,12 +31,9 @@ public class GlassConnectionHandler extends AbstractFenceConnectionHandler{
         super(blockConnections, key);
     }
 
+    @Override
     protected Byte getStates(UserConnection user, Position position, int blockState) {
-        byte states = 0;
-        if (connects(BlockFace.EAST, getBlockData(user, position.getRelative(BlockFace.EAST)))) states |= 1;
-        if (connects(BlockFace.NORTH, getBlockData(user, position.getRelative(BlockFace.NORTH)))) states |= 2;
-        if (connects(BlockFace.SOUTH, getBlockData(user, position.getRelative(BlockFace.SOUTH)))) states |= 4;
-        if (connects(BlockFace.WEST, getBlockData(user, position.getRelative(BlockFace.WEST)))) states |= 8;
+        final Byte states = super.getStates(user, position, blockState);
         return states == 0 && (ProtocolRegistry.SERVER_PROTOCOL <= 47 && ProtocolRegistry.SERVER_PROTOCOL != -1) ? 15 : states;
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/blockconnections/GlassConnectionHandler.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/blockconnections/GlassConnectionHandler.java
@@ -1,5 +1,10 @@
 package us.myles.ViaVersion.protocols.protocol1_13to1_12_2.blockconnections;
 
+import us.myles.ViaVersion.api.data.UserConnection;
+import us.myles.ViaVersion.api.minecraft.BlockFace;
+import us.myles.ViaVersion.api.minecraft.Position;
+import us.myles.ViaVersion.api.protocol.ProtocolRegistry;
+
 public class GlassConnectionHandler extends AbstractFenceConnectionHandler{
 
     static void init() {
@@ -25,5 +30,14 @@ public class GlassConnectionHandler extends AbstractFenceConnectionHandler{
 
     public GlassConnectionHandler(String blockConnections, String key) {
         super(blockConnections, key);
+    }
+
+    protected Byte getStates(UserConnection user, Position position, int blockState) {
+        byte states = 0;
+        if (connects(BlockFace.EAST, getBlockData(user, position.getRelative(BlockFace.EAST)))) states |= 1;
+        if (connects(BlockFace.NORTH, getBlockData(user, position.getRelative(BlockFace.NORTH)))) states |= 2;
+        if (connects(BlockFace.SOUTH, getBlockData(user, position.getRelative(BlockFace.SOUTH)))) states |= 4;
+        if (connects(BlockFace.WEST, getBlockData(user, position.getRelative(BlockFace.WEST)))) states |= 8;
+        return states == 0 && (ProtocolRegistry.SERVER_PROTOCOL <= 47 && ProtocolRegistry.SERVER_PROTOCOL != -1) ? 15 : states;
     }
 }


### PR DESCRIPTION
In and below 1.8, glass panes without any connections connected on all 4 sides with air, which has been changed in 1.9.
This should at least fix the wrong client hitbox for 1.13 clients (and only for 1.8 servers)